### PR TITLE
FIX CRAN examples failures on NA dates

### DIFF
--- a/R/time_seq.R
+++ b/R/time_seq.R
@@ -51,11 +51,11 @@
 #' today <- today()
 #' now <- now()
 #'
-#' time_seq(today, today + months(1), time = "day")
+#' time_seq(today, today %m+% months(1), time = "day")
 #' time_seq(today, length.out = 10, time = "day")
 #' time_seq(today, length.out = 10, time = "hour")
 #'
-#' time_seq(today, today + months(1), time = timespan("days", 1)) # Alternative
+#' time_seq(today, today %m+% months(1), time = timespan("days", 1)) # Alternative
 #' time_seq(today, today + years(1), time = "week")
 #' time_seq(today, today + years(1), time = "fortnight")
 #' time_seq(today, today + years(1), time = "year")

--- a/man/time_seq.Rd
+++ b/man/time_seq.Rd
@@ -97,11 +97,11 @@ collapse::set_collapse(nthreads = 1L)
 today <- today()
 now <- now()
 
-time_seq(today, today + months(1), time = "day")
+time_seq(today, today \%m+\% months(1), time = "day")
 time_seq(today, length.out = 10, time = "day")
 time_seq(today, length.out = 10, time = "hour")
 
-time_seq(today, today + months(1), time = timespan("days", 1)) # Alternative
+time_seq(today, today \%m+\% months(1), time = timespan("days", 1)) # Alternative
 time_seq(today, today + years(1), time = "week")
 time_seq(today, today + years(1), time = "fortnight")
 time_seq(today, today + years(1), time = "year")


### PR DESCRIPTION
Hi, 

CRAN picked the revdep error while checking `timechange` on 29th of Januarry. The culprit is the use of `today + months(1)` which lands on february 29 which does not exist and we get:

```R
  > ## Don't show:
  > .n_dt_threads <- data.table::getDTthreads()
  > .n_collapse_threads <- collapse::get_collapse()$nthreads
  > data.table::setDTthreads(threads = 1L)
  > collapse::set_collapse(nthreads = 1L)
  > ## End(Don't show)
  > # Dates
  > today <- today()
  > now <- now()
  >
  > time_seq(today, today + months(1), time = "day")
  Error in cheapr::sequence_(size, from, by, add_id) :
    size must not contain NA values
  Calls: time_seq ... date_seq_v2 -> sequences -> time_cast -> <Anonymous>
  Execution halted
```

I have replaced the `+` operator with `%m+%` to fix such cases. 
